### PR TITLE
Fixes #16: Fix broken stations

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -1,142 +1,115 @@
 [
   {
     "DisplayName": "Nation Radio",
-    "StationImg": "nation.png",
-    "audioURL": "http:\/\/icy-e-03-boh.sharp-stream.com\/tcnation.aac"
+    "audioURL": "http://icy-e-03-boh.sharp-stream.com/tcnation.aac"
   },
   {
     "DisplayName": "Capital FM",
-    "StationImg": "capital.png",
-    "audioURL": "http:\/\/media-ice.musicradio.com\/CapitalUKMP3"
+    "audioURL": "http://media-ice.musicradio.com/CapitalUKMP3"
   },
   {
     "DisplayName": "Kiss FM",
-    "StationImg": "kiss.png",
-    "audioURL": "http:\/\/icy-e-ba-04-cr.sharp-stream.com\/kiss100low.mp3"
-  },
-  {
-    "DisplayName": "BBC 1",
-    "StationImg": "bbc1.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio1_mf_p"
-  },
-  {
-    "DisplayName": "BBC 1 Xtra",
-    "StationImg": "bbc1x.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio1xtra_mf_p"
-  },
-  {
-    "DisplayName": "BBC 2",
-    "StationImg": "bbc2.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio2_mf_p"
-  },
-  {
-    "DisplayName": "BBC 3",
-    "StationImg": "bbc3.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio3_mf_p"
-  },
-  {
-    "DisplayName": "BBC 4",
-    "StationImg": "bbc4.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio4fm_mf_p"
-  },
-  {
-    "DisplayName": "BBC 4 Extra",
-    "StationImg": "bbc4x.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio4extra_mf_p"
-  },
-  {
-    "DisplayName": "BBC 5",
-    "StationImg": "bbc5.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio5live_mf_p"
-  },
-  {
-    "DisplayName": "BBC 6",
-    "StationImg": "bbc6.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_6music_mf_p"
-  },
-  {
-    "DisplayName": "BBC 5 Extra",
-    "StationImg": "bbc5x.png",
-    "audioURL": "http:\/\/bbcmedia.ic.llnwd.net\/stream\/bbcmedia_radio5extra_mf_p"
-  },
-  {
-    "DisplayName": "Heart",
-    "StationImg": "heart.png",
-    "audioURL": "http:\/\/media-ice.musicradio.com\/HeartSouthWalesMP3"
+    "audioURL": "https://stream-kiss.planetradio.co.uk/kissnational.aac"
   },
   {
     "DisplayName": "Kisstory",
-    "StationImg": "kisstory.png",
-    "audioURL": "http:\/\/icy-e-bl-05-cr.sharp-stream.com\/kisstorylow.mp3"
+    "audioURL": "https://stream-al.planetradio.co.uk/kisstory.aac"
+  },  
+  {
+    "DisplayName": "BBC 1",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio1_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 1 Xtra",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio1xtra_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 2",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio2_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 3",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio3_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 4",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio4fm_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 4 Extra",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio4extra_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 5",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio5live_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "BBC 6",
+    "audioURL": "http://bbcmedia.ic.llnwd.net/stream/bbcmedia_6music_mf_p",
+    "cors": false
+  },
+  {
+    "DisplayName": "Heart",
+    "audioURL": "http://media-ice.musicradio.com/HeartSouthWalesMP3"
   },
   {
     "DisplayName": "Smooth South Wales",
-    "StationImg": "smooth.png",
-    "audioURL": "http:\/\/media-ice.musicradio.com\/SmoothSouthWalesMP3"
+    "audioURL": "http://media-ice.musicradio.com/SmoothSouthWalesMP3"
   },
   {
     "DisplayName": "Classic FM",
-    "StationImg": "classic.png",
-    "audioURL": "http:\/\/media-ice.musicradio.com\/ClassicFMMP3"
+    "audioURL": "http://media-ice.musicradio.com/ClassicFMMP3"
   },
   {
     "DisplayName": "Magic",
-    "StationImg": "magic.png",
-    "audioURL": "http:\/\/icy-e-bz-04-cr.sharp-stream.com\/magic1054low.mp3"
+    "audioURL": "https://stream-mz.planetradio.co.uk/magicnational.aac"
   },
   {
     "DisplayName": "Radio X",
-    "StationImg": "x.png",
-    "audioURL": "http:\/\/media-ice.musicradio.com\/RadioXUKMP3"
+    "audioURL": "http://media-ice.musicradio.com/RadioXUKMP3"
   },
   {
     "DisplayName": "London Broadcast Channel (LBC)",
-    "StationImg": "LBC.png",
-    "audioURL": "http:\/\/media-ice.musicradio.com\/LBCLondonMP3"
+    "audioURL": "http://media-ice.musicradio.com/LBCLondonMP3"
   },
   {
     "DisplayName": "Choice Radio",
-    "StationImg": "choice.png",
-    "audioURL": "http:\/\/149.255.59.164:8138\/stream?type=http&nocache=10323"
+    "audioURL": "http://149.255.59.164:8138/stream?type=http&nocache=10323"
   },
   {
     "DisplayName": "Frag Radio",
-    "StationImg": "frag.png",
-    "audioURL": "http:\/\/stream.fragradio.co.uk:8000\/live"
+    "audioURL": "http://stream.fragradio.co.uk:8000/live"
   },
   {
     "DisplayName": "HIVE 365",
-    "StationImg": "hive.png",
-    "audioURL": "http:\/\/stream.hive365.co.uk:8088\/live"
+    "audioURL": "http://stream.hive365.co.uk:8088/live"
   },
   {
     "DisplayName": "Virgin Radio",
-    "StationImg": "virgin.png",
-    "audioURL": "http:\/\/radio.virginradio.co.uk\/stream"
-  },
-  {
-    "DisplayName": "Trkvz",
-    "StationImg": "#",
-    "audioURL": "http:\/\/trkvz-radyo.ercdn.net\/rdaspor\/rdaspor_1.m3u8"
+    "audioURL": "http://radio.virginradio.co.uk/stream"
   },
   {
     "DisplayName": "Rinse FM",
-    "StationImg" : "#",
-    "audioURL"   : "http:\/\/streamer.dgen.net:8000\/rinseradio"
+    "audioURL"   : "http://206.189.117.157:8000/stream",
+    "cors": false
   },
   {
     "DisplayName": "NTS London Live",
-    "StationImg" : "#",
-    "audioURL"   : "https:\/\/stream-relay-geo.ntslive.net\/stream?t=1532730119940"
+    "audioURL"   : "https://stream-relay-geo.ntslive.net/stream?t=1532730119940"
   },
   {
     "DisplayName": "Sub FM",
-    "StationImg" : "#",
-    "audioURL"   : "http:\/\/listen.sub.fm\/hi"
+    "audioURL"   : "https://subfm.radioca.st/live"
   },
   {
     "DisplayName": "UK Bass Radio",
-    "StationImg" : "#",
-    "audioURL"   : "http:\/\/uk3-pn.mixstream.net:8210\/;\/;685782922574517stream.nsv"
+    "audioURL"   : "http://stream.sonixcast.com:8016/listen.mp3"
   }
 ]

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -178,14 +178,16 @@ function changeStation (id)
     let stationURL = stations[id].audioURL;
     let stationName = stations[id].DisplayName;
 
+    let cors = stations[id].hasOwnProperty('cors') ? stations[id].cors : true;
+
     $('#stationName').text(stationName);
-    updateStationAudio(stationURL);
+    updateStationAudio(stationURL, cors);
 
     docCookies.setItem( 'station_id', id );
     document.querySelector('title').innerText = `${base_page_title} - ${stationName}`;
 }
 
-function updateStationAudio(stationurl)
+function updateStationAudio(stationurl, cors)
 {
     var track = current_track === 2 ? 1 : 2;
     let new_audio = $(`#stationAudioTrack${track}`);
@@ -205,6 +207,13 @@ function updateStationAudio(stationurl)
 
     hls.destroy();
     console.log('Starting Track: '+track);
+    
+    if (cors) {
+        new_audio[0].setAttribute('crossorigin', 'anonymous');
+    } else {
+        new_audio[0].removeAttribute('crossorigin');
+    }
+
     new_audio.attr('src', stationurl);
     new_audio[0].volume = 0;
     new_audio[0].play();


### PR DESCRIPTION
Removed Trkvz

Removed station img since its obsolute

Fixed Kisstory Audio URLS

Fixed Magic audio url

Fixed RinseFM audio URL & BBC Stations

Fixed UK BASS Radio Stream

Fixed SUBFM Audio url

Removed escaped slashes from stations.json since not needed

Fixed CORS attribute for RinseFM